### PR TITLE
Make rippled's Json::Reader available

### DIFF
--- a/src/unity/ripple-libpp.cpp
+++ b/src/unity/ripple-libpp.cpp
@@ -77,6 +77,7 @@
 #include <ripple/crypto/impl/RFC1751.cpp>
 #include <ripple/json/impl/json_value.cpp>
 #include <ripple/json/impl/json_valueiterator.cpp>
+#include <ripple/json/impl/json_reader.cpp>
 #include <ripple/json/impl/json_writer.cpp>
 #include <ripple/json/impl/to_string.cpp>
 


### PR DESCRIPTION
Pretty trivial oversight. It's not used in the demo, but that's not the point.